### PR TITLE
Update Snappy to Version 1.1.9

### DIFF
--- a/recipe/fix_win_exports.patch
+++ b/recipe/fix_win_exports.patch
@@ -1,0 +1,15 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 672561e..f013093 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -260,6 +260,10 @@ if(SNAPPY_BUILD_TESTS OR SNAPPY_BUILD_BENCHMARKS)
+       "${PROJECT_BINARY_DIR}/config.h"
+   )
+ 
++  if(BUILD_SHARED_LIBS)
++    set_target_properties(snappy_test_support PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
++  endif(BUILD_SHARED_LIBS)
++
+   # Test files include snappy-test.h, HAVE_CONFIG_H must be defined.
+   target_compile_definitions(snappy_test_support PUBLIC -DHAVE_CONFIG_H)
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,8 @@ source:
   - url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
     fn: snappy-{{ version }}.tar.gz
     sha256: {{ sha256 }}
-    #patches:
+    patches:  # [win]
+      - fix_win_exports.patch  # [win]  Ensure `snappy_test_support.lib` is built.
       # Have snappy-unittest not run the slow-ish microbenchmarks, but just
       # the quick correctness tests, without bothering with gflags (which didn't
       # work out of the box). This is the recommended method in the README.
@@ -18,7 +19,6 @@ source:
       # the dynamic library, since they have the same suffix there.
       # https://github.com/google/snappy/pull/57
       #- windows-static-lib-name.patch
-
     # these are git submodules
   - url: https://github.com/google/benchmark/archive/bf585a2789e30585b4e3ce6baf11ef2750b54677.tar.gz
     sha256: 8222ebe7d9049c4b8bb3f930e3ca08e232f5587ad4121619f73f6ce374391c70

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     # Have snappy-unittest not run the slow-ish microbenchmarks, but just
     # the quick correctness tests, without bothering with gflags (which didn't
     # work out of the box). This is the recommended method in the README.
-    - skip-microbenchmarks.patch
+    #- skip-microbenchmarks.patch
     # Name the static library snappy_static.lib on windows, to distinguish from
     # the dynamic library, since they have the same suffix there.
     # https://github.com/google/snappy/pull/57
@@ -33,6 +33,9 @@ requirements:
     - make  # [unix]
     - cmake
     - msinttypes  # [win and vc<14]
+    - patch  # [not win]
+    - m2-patch  # [win]
+    - git
 
 test:
   commands:
@@ -48,7 +51,7 @@ test:
 
 about:
   home: https://github.com/google/snappy
-  license: BSD 3-clause
+  license: BSD-3-clause AND CC-BY-3.0 AND MIT AND CC-BY AND Public Domain
   license_file: COPYING
   license_family: BSD
   summary: A fast compressor/decompressor
@@ -60,6 +63,7 @@ about:
     inputs, but the resulting compressed files are anywhere from 20% to 100%
     bigger.
   dev_url: https://github.com/google/snappy
+  doc_url: https://github.com/google/snappy/tree/master/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.8" %}
-{% set sha256 = "16b677f07832a612b0836178db7f374e414f94657c138e6993cbfc5dcc58651f" %}
+{% set version = "1.1.9" %}
+{% set sha256 = "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7" %}
 
 package:
   name: snappy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,25 +6,33 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
-  fn: snappy-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-  patches:
-    # Have snappy-unittest not run the slow-ish microbenchmarks, but just
-    # the quick correctness tests, without bothering with gflags (which didn't
-    # work out of the box). This is the recommended method in the README.
-    #- skip-microbenchmarks.patch
-    # Name the static library snappy_static.lib on windows, to distinguish from
-    # the dynamic library, since they have the same suffix there.
-    # https://github.com/google/snappy/pull/57
-    - windows-static-lib-name.patch
+  - url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
+    fn: snappy-{{ version }}.tar.gz
+    sha256: {{ sha256 }}
+    #patches:
+      # Have snappy-unittest not run the slow-ish microbenchmarks, but just
+      # the quick correctness tests, without bothering with gflags (which didn't
+      # work out of the box). This is the recommended method in the README.
+      #- skip-microbenchmarks.patch
+      # Name the static library snappy_static.lib on windows, to distinguish from
+      # the dynamic library, since they have the same suffix there.
+      # https://github.com/google/snappy/pull/57
+      #- windows-static-lib-name.patch
+
+    # these are git submodules
+  - url: https://github.com/google/benchmark/archive/bf585a2789e30585b4e3ce6baf11ef2750b54677.tar.gz
+    sha256: 8222ebe7d9049c4b8bb3f930e3ca08e232f5587ad4121619f73f6ce374391c70
+    folder: third_party/benchmark
+  - url: https://github.com/google/googletest/archive/18f8200e3079b0e54fa00cb7ac55d4c39dcf6da6.tar.gz
+    sha256: d518c1c146c5a87cdedbee8535a396f95d91e8b39baa539fd4c50bd62148d199
+    folder: third_party/googletest
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # other than a fluke at 1.1.5, it's stable
     #   https://abi-laboratory.pro/tracker/timeline/snappy/
-    - {{ pin_subpackage('snappy') }}
+    - {{ pin_subpackage('snappy', max_pin='x') }}
 
 requirements:
   build:
@@ -32,10 +40,11 @@ requirements:
     - {{ compiler('cxx') }}
     - make  # [unix]
     - cmake
-    - msinttypes  # [win and vc<14]
     - patch  # [not win]
     - m2-patch  # [win]
     - git
+  host:
+    - msinttypes  # [win and vc<14]
 
 test:
   commands:


### PR DESCRIPTION

1. check the upstream
    https://github.com/google/snappy/tree/1.1.9

2. check the pinnings
    https://github.com/google/snappy/blob/1.1.9/snappy_unittest.cc

3. check changelogs
    https://github.com/google/snappy/blob/1.1.9/NEWS

    There were no breanking changes mentioned in the changelog.

4. additional research
    https://github.com/conda-forge/snappy-feedstock/issues

    There were no open issues mentioned at the time of the review. 

5. verify dev_url
    https://github.com/google/snappy

6. verify doc_url
    https://github.com/google/snappy/tree/master/docs

7. verify pip in the test section
8. verify the test section
9. additional tests

In order to test the `snappy` package version `1.1.9` the following command was used:
`conda build snappy-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `snappy` to version `1.1.9`
