### PR TITLE
Update to 1.1.10 and debundle gtest and gmock

### DIFF
--- a/recipe/0001-Omit-Werror-during-compilation.patch
+++ b/recipe/0001-Omit-Werror-during-compilation.patch
@@ -1,0 +1,29 @@
+From 953b72083de19c04c6eb81b18bbe3e0ad1b29393 Mon Sep 17 00:00:00 2001
+From: "Uwe L. Korn" <uwe.korn@quantco.com>
+Date: Sat, 11 Mar 2023 12:13:29 +0100
+Subject: [PATCH] Omit Werror during compilation
+
+---
+ CMakeLists.txt | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 84bf188..bdb5903 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,13 +70,6 @@ else(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
+   endif(NOT CMAKE_CXX_FLAGS MATCHES "-Wextra")
+ 
+-  # Use -Werror for clang only.
+-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-    if(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
+-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+-    endif(NOT CMAKE_CXX_FLAGS MATCHES "-Werror")
+-  endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-
+   # Disable C++ exceptions.
+   string(REGEX REPLACE "-fexceptions" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+-- 
+2.37.1 (Apple Git-137.1)

--- a/recipe/0002-Debundle-gtest-and-gmock.patch
+++ b/recipe/0002-Debundle-gtest-and-gmock.patch
@@ -1,0 +1,48 @@
+From ea9f3cdaf3968c29908f72724eee812963289c50 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Fri, 15 Dec 2023 15:57:00 -0500
+Subject: [PATCH] Debundle gtest and gmock
+
+---
+ CMakeLists.txt | 19 ++-----------------
+ 1 file changed, 2 insertions(+), 17 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c3062e2..080fff5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -306,29 +306,14 @@ endif(SNAPPY_BUILD_TESTS OR SNAPPY_BUILD_BENCHMARKS)
+ if(SNAPPY_BUILD_TESTS)
+   enable_testing()
+ 
+-  # Prevent overriding the parent project's compiler/linker settings on Windows.
+-  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+-  set(install_gtest OFF)
+-  set(install_gmock OFF)
+-  set(build_gmock ON)
+-
+-  # This project is tested using GoogleTest.
+-  add_subdirectory("third_party/googletest")
+-
+-  # GoogleTest triggers a missing field initializers warning.
+-  if(SNAPPY_HAVE_NO_MISSING_FIELD_INITIALIZERS)
+-    set_property(TARGET gtest
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-    set_property(TARGET gmock
+-        APPEND PROPERTY COMPILE_OPTIONS -Wno-missing-field-initializers)
+-  endif(SNAPPY_HAVE_NO_MISSING_FIELD_INITIALIZERS)
++  find_package(GTest REQUIRED)
+ 
+   add_executable(snappy_unittest "")
+   target_sources(snappy_unittest
+     PRIVATE
+       "snappy_unittest.cc"
+   )
+-  target_link_libraries(snappy_unittest snappy_test_support gmock_main gtest)
++  target_link_libraries(snappy_unittest snappy_test_support GTest::gmock_main GTest::gtest)
+ 
+   add_test(
+     NAME snappy_unittest
+-- 
+2.43.0
+

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cmake -G "NMake Makefiles" ^
     -DCMAKE_PREFIX_PATH:PATH="%LIBRARY_PREFIX%" ^
     -DCMAKE_BUILD_TYPE:STRING=Release ^
     -DBUILD_SHARED_LIBS=ON ^
+    -DSNAPPY_BUILD_BENCHMARKS=OFF ^
     ..
 if errorlevel 1 exit 1
 
@@ -36,6 +37,7 @@ cmake -G "NMake Makefiles" ^
     -DCMAKE_BUILD_TYPE:STRING=Release ^
     -DCMAKE_POSITION_INDEPENDENT_CODE=1 ^
     -DBUILD_SHARED_LIBS=OFF ^
+    -DSNAPPY_BUILD_BENCHMARKS=OFF ^
     ..
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -21,9 +21,10 @@ function build() {
         -DCMAKE_PREFIX_PATH="$PREFIX" \
         -DCMAKE_INSTALL_LIBDIR=lib \
         -DHAVE_LIBZ=FALSE -DHAVE_LIBLZO2=FALSE \
+        -DSNAPPY_BUILD_BENCHMARKS=OFF \
         $extra_args
 
-    make -j${CPU_COUNT} ${VERBOSE_CM}
+    make -j${CPU_COUNT}
 
     # need to be in the root directory for this to run properly
     cd ..

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "1.1.9" %}
-{% set sha256 = "75c1fbb3d618dd3a0483bff0e26d0a92b495bbe5059c8b4f1c962b478b6e06e7" %}
+{% set version = "1.1.10" %}
+{% set sha256 = "49d831bffcc5f3d01482340fe5af59852ca2fe76c3e05df0e67203ebbe0f1d90" %}
 
 package:
   name: snappy
@@ -7,26 +7,21 @@ package:
 
 source:
   - url: https://github.com/google/snappy/archive/{{ version }}.tar.gz
-    fn: snappy-{{ version }}.tar.gz
     sha256: {{ sha256 }}
     patches:
-      - Add_inline.patch
+      # - Add_inline.patch
       - fix_win_exports.patch  # [win]  Ensure `snappy_test_support.lib` is built.
-
-  # these are git submodules
-  - url: https://github.com/google/benchmark/archive/bf585a2789e30585b4e3ce6baf11ef2750b54677.tar.gz
-    sha256: 8222ebe7d9049c4b8bb3f930e3ca08e232f5587ad4121619f73f6ce374391c70
-    folder: third_party/benchmark
-  - url: https://github.com/google/googletest/archive/18f8200e3079b0e54fa00cb7ac55d4c39dcf6da6.tar.gz
-    sha256: d518c1c146c5a87cdedbee8535a396f95d91e8b39baa539fd4c50bd62148d199
-    folder: third_party/googletest
+      - 0001-Omit-Werror-during-compilation.patch
+      - 0002-Debundle-gtest-and-gmock.patch
 
 build:
-  number: 0
+  number: 1
   run_exports:
     # other than a fluke at 1.1.5, it's stable
     #   https://abi-laboratory.pro/tracker/timeline/snappy/
     - {{ pin_subpackage('snappy', max_pin='x') }}
+  ignore_run_exports:
+    - gtest
 
 requirements:
   build:
@@ -34,13 +29,12 @@ requirements:
     - {{ compiler('cxx') }}
     - make  # [unix]
     - cmake
-    - git
-    - m2-patch   # [win]
+    - git  # [not win]
+    - m2-patch  # [win]
     - patch  # [not win]
   host:
     - msinttypes  # [win and vc<14]
-    - patch     # [not win]
-    - m2-patch  # [win]
+    - gtest  # We run the tests during the build, so we need gtest
 
 test:
   commands:


### PR DESCRIPTION
snappy 1.1.10

**Destination channel:** defaults

### Links

- [PKG-3681](https://anaconda.atlassian.net/browse/PKG-3681)
- [Upstream repository](https://github.com/google/snappy/tree/1.1.10)
- [Upstream changelog/diff](https://github.com/google/snappy/compare/1.1.9..1.1.10)

### Explanation of changes:

This PR removes files that were wrongly bundled in our snappy packages. This was caused by gtest and gmock being compiled on the fly and being installed alongside snappy. See https://conda-metadata-app.streamlit.app/?q=pkgs%2Fmain%2Flinux-64%2Fsnappy-1.1.9-h295c915_0.conda#files to see the files in our current package.

So this PR de-bundles gmock and gtest.

This will make conda happy (it will stop complaining about overriding existing files from other packages)

[PKG-3681]: https://anaconda.atlassian.net/browse/PKG-3681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ